### PR TITLE
Fix CoverDevice is deprecated warnings with HA > 0.110

### DIFF
--- a/config/custom_components/elero/cover.py
+++ b/config/custom_components/elero/cover.py
@@ -12,7 +12,7 @@ from homeassistant.components.cover import (ATTR_POSITION, ATTR_TILT_POSITION,
                                             SUPPORT_SET_POSITION,
                                             SUPPORT_SET_TILT_POSITION,
                                             SUPPORT_STOP, SUPPORT_STOP_TILT,
-                                            CoverDevice)
+                                            CoverEntity)
 from homeassistant.components.light import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_COVERS, CONF_DEVICE_CLASS, CONF_NAME,
                                  STATE_CLOSED, STATE_CLOSING, STATE_OPEN,
@@ -140,7 +140,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(covers, True)
 
 
-class EleroCover(CoverDevice):
+class EleroCover(CoverEntity):
     """Representation of a Elero cover device."""
 
     def __init__(


### PR DESCRIPTION
With HA > 0.110 the entity class names were renamed as per [developer blog](https://developers.home-assistant.io/blog/2020/05/14/entity-class-names/). Using the old CoverDevice will generate the following warnings in the log:

`WARNING (MainThread) [homeassistant.components.cover] CoverDevice is deprecated, modify elero to extend CoverEntity`

This PR switched to the new CoverEntity. I already did the modifications locally and it works for me running HA 0.111.4