### PR TITLE
Fix device_state_attributes warning

### DIFF
--- a/config/custom_components/elero/cover.py
+++ b/config/custom_components/elero/cover.py
@@ -233,7 +233,7 @@ class EleroCover(CoverEntity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         data = {}
 


### PR DESCRIPTION
The usage of `device_state_attributes` is deprecated as per home-assistant/core#47304. This PR replaces it with the new `extra_state_attributes`.