### PR TITLE
Fix Shutdown Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Feature branches with lots of small commits (especially titled "oops", "fix typo
 ---
 
 # Version
+* 3.2.1 - March 10, 2022 [Fix TypeError on HA Shutdowm](https://github.com/W00D00/home-assistant-elero/pull/36)
 * 3.2.0 - March 10, 2022 [Added support for HACS](https://github.com/W00D00/home-assistant-elero/issues/23)
 * 3.1.0 - March 5, 2022 [Update dependencies for pip 20.3](https://github.com/W00D00/home-assistant-elero/issues/29)
 * 3.0.0 - April 23, 2021 [Update manifest.json with version.](https://github.com/W00D00/home-assistant-elero/commit/d6bce117bc26c9b4cf54b649060e8ea3a8538816)

--- a/custom_components/elero/__init__.py
+++ b/custom_components/elero/__init__.py
@@ -1,6 +1,6 @@
 """Support for Elero electrical drives."""
 
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 
 import logging
 

--- a/custom_components/elero/__init__.py
+++ b/custom_components/elero/__init__.py
@@ -151,7 +151,7 @@ def setup(hass, config):
     ELERO_TRANSMITTERS = EleroTransmitters(transmitters_config)
     ELERO_TRANSMITTERS.discover()
 
-    def close_serial_ports():
+    def close_serial_ports(event):
         """Close the serial port."""
         ELERO_TRANSMITTERS.close_transmitters()
 

--- a/custom_components/elero/cover.py
+++ b/custom_components/elero/cover.py
@@ -1,6 +1,6 @@
 """Support for Elero cover components."""
 
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 
 import logging
 

--- a/custom_components/elero/manifest.json
+++ b/custom_components/elero/manifest.json
@@ -1,6 +1,6 @@
 {
     "domain": "elero",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "name": "Elero",
     "documentation": "https://github.com/W00D00/home-assistant-elero",
     "dependencies": [],


### PR DESCRIPTION
The handler for the Homeassistant shutdown event is missing the event parameter and results in a TypeError when Homeassistant is stopped. 

HA Log entry during shutdown:
```
ERROR (MainThread) [homeassistant] Error doing job: Future exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
TypeError: close_serial_ports() takes 0 positional arguments but 1 was given
```

This PR fixes the missing event parameter.